### PR TITLE
No-skip flag runs even those tests which are skipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,5 @@ Please make sure you pull latest code before running the tests.
 
 1. For all tests to execute: run `python3 -m pytest` when being in `erigon-automated-testing` directory. In order to run specific test to run you may execute: `python3 -m pytest tests/test_block_creation_mvp.py::TestMVPTestCase::test_valid_transactions`
 2. In a case of failed tests results are printed on screen and detailed report is kept in result.xml
+
+Use --no-skips to run even 'skipped' tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
-
+import pytest
+import _pytest.skipping
 
 def pytest_addoption(parser):
     parser.addoption(
@@ -11,6 +12,10 @@ def pytest_addoption(parser):
         default="",
         help="Directory to store log if tests failed",
     )
+    parser.addoption(
+        "--no-skips",
+        action="store_true",
+        default=False, help="disable skip marks")
 
 
 @dataclass
@@ -24,3 +29,14 @@ option = Option()
 def pytest_configure(config):
     global option
     option = config.option
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_cmdline_preparse(config, args):
+    if "--no-skips" not in args:
+        return
+
+    def no_skip():
+        return
+
+    _pytest.skipping.skip = no_skip


### PR DESCRIPTION
We are skipping some test because they may produce bugs which are "braking" test suite run. But when the bug is fixed we need to run the tests in order to verify the bug is fixed. 
Adding `--no-skips` arg to command line (or `pytest.ini` will run even those tests which are skipped)